### PR TITLE
Fjerne arbeidstid i prosent

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -69,7 +69,6 @@ jobs:
                   CLUSTER: dev-gcp
                   RESOURCE: nais/naiserator.yml
                   VARS: nais/dev-gcp.json
-                  NPM_CONFIG_CACHE: /tmp
 
     deploy-prod-gcp:
         name: deploy-prod-gcp

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -69,6 +69,7 @@ jobs:
                   CLUSTER: dev-gcp
                   RESOURCE: nais/naiserator.yml
                   VARS: nais/dev-gcp.json
+                  NPM_CONFIG_CACHE: /tmp
 
     deploy-prod-gcp:
         name: deploy-prod-gcp

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -7,10 +7,9 @@ on:
             - '.gitignore'
             - 'LICENCE'
             - 'CODEOWNERS'
-        branches:
 
 env:
-    IMAGE: docker.pkg.github.com/${{ github.repository }}/pleiepenger-i-livets-sluttfase:${{ github.sha }}
+    IMAGE: ghcr.io/${{ github.repository }}/pleiepenger-i-livets-sluttfase:${{ github.sha }}
 
 jobs:
     test:
@@ -54,7 +53,7 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
+                  docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
                   docker push ${IMAGE}
 
     deploy-dev-gcp:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:16-alpine
 
+ENV NPM_CONFIG_CACHE=/tmp
+
 WORKDIR /usr/src/app
 
 COPY dist ./dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM node:16-alpine
-
 ENV NPM_CONFIG_CACHE=/tmp
 
 WORKDIR /usr/src/app

--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -16,6 +16,7 @@
         "LOGIN_URL": "https://loginservice.dev.nav.no/login?redirect=https://pleiepenger-i-livets-sluttfase.dev.nav.no/familie/sykdom-i-familien/soknad/pleiepenger-i-livets-sluttfase/soknad",
         "APPSTATUS_PROJECT_ID": "ryujtq87",
         "APPSTATUS_DATASET": "staging",
-        "USE_AMPLITUDE": "false"
+        "USE_AMPLITUDE": "false",
+        "NPM_CONFIG_CACHE": "/tmp"
     }
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -16,6 +16,7 @@ import ApplicationWrapper from './components/application-wrapper/ApplicationWrap
 import AppStatusWrapper from '@navikt/sif-common-core/lib/components/app-status-wrapper/AppStatusWrapper';
 import UnavailablePage from './pages/unavailable-page/UnavailablePage';
 import Modal from 'nav-frontend-modal';
+import './styles/app.less';
 
 export const APPLICATION_KEY = 'pleiepenger-i-livets-sluttfase-soknad';
 export const SKJEMANAVN = 'Søknad om pleiepenger i livets sluttfase';

--- a/src/app/i18n/nb.json
+++ b/src/app/i18n/nb.json
@@ -281,8 +281,8 @@
     "arbeidIPeriode.søkerKunHelgedager.alert.avsnitt.2": "Du kan derfor ikke registrere arbeid kun for lørdag og/eller søndag.",
     "arbeidIPeriode.søkerKunHelgedager.alert.avsnitt.3": "Vennligst gå tilbake til steg \"Perioden med pleiepenger\" og sjekk informasjonen du har fylt ut. Når du har gjort det, trykker du på \"Fortsett\"-knappen for å gå videre.",
 
-    "arbeidIPeriode.StepInfo.1": "Nå trenger vi å vite om du jobbet noe i perioden du har brukt pleiepenger. Dette er informasjon vi trenger, fordi vi graderer pleiepengene mot den tiden du jobber.",
-    "arbeidIPeriode.StepInfo.2": "Gradering betyr at pleiepengene reduseres. Hvis du i søknadsperioden for eksempel jobbet 50 prosent, kan du ha rett til 50 prosent pleiepenger.",
+    "arbeidIPeriode.StepInfo.1": "Nå må vi vite om du har jobbet noe i perioden du har hatt pleiepenger.",
+    "arbeidIPeriode.StepInfo.2": "Hvis du for eksempel har pleid den som er syk en halv dag og jobbet resten av dagen, bruker du også bare en halv dag med pleiepenger. De dagene du jobber fullt, bruker du ikke av pleiepengedagene.",
     "arbeidIPeriode.FrilansLabel": "Frilans",
     "arbeidIPeriode.SNLabel": "Selvstendig næringsdrivende",
     "arbeidIPeriode.jobberIPerioden.spm": "Jobbet du noe {hvor} i perioden du søker for?",

--- a/src/app/soknad/arbeidstid-step/shared/arbeid-i-periode-spørsmål/ArbeidIPeriodeSpørsmål.tsx
+++ b/src/app/soknad/arbeidstid-step/shared/arbeid-i-periode-spørsmål/ArbeidIPeriodeSpørsmål.tsx
@@ -29,6 +29,8 @@ import { getJobberIPeriodenValidator } from '../validation/jobberIPeriodenSpørs
 import InfoSøkerKunHelgedager from './InfoSøkerKunHelgedager';
 import ExpandableInfo from '@navikt/sif-common-core/lib/components/expandable-content/ExpandableInfo';
 
+const BRUK_KUN_KORT_PERIODE = true;
+
 interface Props extends ArbeidstidRegistrertLogProps {
     parentFieldName: string;
     arbeidsforhold: Arbeidsforhold | ArbeidsforholdFrilanser;
@@ -80,7 +82,7 @@ const ArbeidIPeriodeSpørsmål = ({
 
     const { arbeidIPeriode } = arbeidsforhold;
     const { jobberIPerioden, timerEllerProsent, erLiktHverUke, jobberProsent } = arbeidIPeriode || {};
-    const erKortPeriode = getWeeksInDateRange(periode).length < 4;
+    const erKortPeriode = getWeeksInDateRange(periode).length < (BRUK_KUN_KORT_PERIODE ? 100 : 4);
 
     const renderArbeidstidVariertPart = (kanLeggeTilPeriode: boolean) => (
         <ArbeidstidVariert

--- a/src/app/soknad/arbeidstid-step/shared/arbeidstid-variert/arbeidstidVariertMessages.ts
+++ b/src/app/soknad/arbeidstid-step/shared/arbeidstid-variert/arbeidstidVariertMessages.ts
@@ -6,7 +6,7 @@ const arbeidstidMessages = {
         'arbeidstidVariert.periode.info.2': 'timer per uke i én eller flere perioder',
         'arbeidstidVariert.periode.info.3': 'timer for enkeltdager ved å velge dag i aktuell måned',
         'arbeidstidVariert.kortPeriode.tittel': 'Hvor mye jobbet du?',
-        'arbeidstidVariert.kortPeriode.info': 'Legg inn timer for enkeltdager ved å velge dag i aktuell måned.',
+        'arbeidstidVariert.kortPeriode.info': 'Legg inn timer ved å velge dag i aktuell måned.',
         'arbeidstidVariert.månedsliste.tittel': 'Registrert jobb',
     },
 };

--- a/src/app/soknad/opplysninger-om-pleietrengende-step/OpplysningerOmPleietrengendeStep.tsx
+++ b/src/app/soknad/opplysninger-om-pleietrengende-step/OpplysningerOmPleietrengendeStep.tsx
@@ -57,16 +57,14 @@ const OpplysningerOmPleietrengendeStep = ({ onValidSubmit }: StepConfigProps) =>
             </CounsellorPanel>
 
             <FormBlock>
-                <Box margin="l">
-                    <SoknadFormComponents.Input
-                        name={SoknadFormField.pleietrengende__navn}
-                        label={intlHelper(intl, 'step.opplysninger-om-pleietrengende.spm.navn')}
-                        validate={validateNavn}
-                        style={{ maxWidth: '20rem' }}
-                    />
-                </Box>
+                <SoknadFormComponents.Input
+                    name={SoknadFormField.pleietrengende__navn}
+                    label={intlHelper(intl, 'step.opplysninger-om-pleietrengende.spm.navn')}
+                    validate={validateNavn}
+                    style={{ maxWidth: '20rem' }}
+                />
 
-                <Box margin="l">
+                <FormBlock>
                     <SoknadFormComponents.Input
                         name={SoknadFormField.pleietrengende__norskIdentitetsnummer}
                         label={intlHelper(intl, 'step.opplysninger-om-pleietrengende.spm.fnr')}
@@ -86,30 +84,32 @@ const OpplysningerOmPleietrengendeStep = ({ onValidSubmit }: StepConfigProps) =>
                         style={{ maxWidth: '20rem' }}
                         disabled={harIkkeFnr}
                     />
-                    <SoknadFormComponents.Checkbox
-                        label={intlHelper(intl, 'step.opplysninger-om-pleietrengende.fnr.harIkkeFnr')}
-                        name={SoknadFormField.harIkkeFnr}
-                        afterOnChange={(newValue) => {
-                            if (newValue) {
-                                resetFieldValue(
-                                    SoknadFormField.pleietrengende__norskIdentitetsnummer,
-                                    setFieldValue,
-                                    initialValues
-                                );
-                            } else {
-                                resetFieldValues(
-                                    [
-                                        SoknadFormField.pleietrengende__årsakManglerIdentitetsnummer,
+                    <Box margin="m">
+                        <SoknadFormComponents.Checkbox
+                            label={intlHelper(intl, 'step.opplysninger-om-pleietrengende.fnr.harIkkeFnr')}
+                            name={SoknadFormField.harIkkeFnr}
+                            afterOnChange={(newValue) => {
+                                if (newValue) {
+                                    resetFieldValue(
                                         SoknadFormField.pleietrengende__norskIdentitetsnummer,
-                                        SoknadFormField.pleietrengende__fødselsdato,
-                                    ],
-                                    setFieldValue,
-                                    initialValues
-                                );
-                            }
-                        }}
-                    />
-                </Box>
+                                        setFieldValue,
+                                        initialValues
+                                    );
+                                } else {
+                                    resetFieldValues(
+                                        [
+                                            SoknadFormField.pleietrengende__årsakManglerIdentitetsnummer,
+                                            SoknadFormField.pleietrengende__norskIdentitetsnummer,
+                                            SoknadFormField.pleietrengende__fødselsdato,
+                                        ],
+                                        setFieldValue,
+                                        initialValues
+                                    );
+                                }
+                            }}
+                        />
+                    </Box>
+                </FormBlock>
                 {harIkkeFnr && (
                     <>
                         <FormBlock>

--- a/src/app/styles/app.less
+++ b/src/app/styles/app.less
@@ -1,0 +1,3 @@
+.m-caps {
+    text-transform: capitalize;
+}

--- a/src/app/types/SøknadTempStorageData.ts
+++ b/src/app/types/SøknadTempStorageData.ts
@@ -1,7 +1,7 @@
 import { StepID } from '../soknad/soknadStepsConfig';
 import { SoknadFormData } from './SoknadFormData';
 
-export const MELLOMLAGRING_VERSION = '2';
+export const MELLOMLAGRING_VERSION = '3';
 
 interface StorageMetadata {
     version: string;


### PR DESCRIPTION
Fjerne mulighet for å oppgi arbeid i prosent. Dette er gjort enkelt ved å tvinge til å vise dialogen som om det er en kort periode, dvs. kun tid for enkeltdager. Endelig løsning er avhengig av hva K9 bestemmer seg for.